### PR TITLE
Updates urls.py

### DIFF
--- a/better500s/urls.py
+++ b/better500s/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 from better500s import BETTER_500_AJAX_URL, BETTER_500_POST_URL
 from better500s import views


### PR DESCRIPTION
Updates from the depreciated django.conf.urls.defaults to the newer
django.conf.urls.

[Django Depreciation Timeline](https://docs.djangoproject.com/en/1.6/internals/deprecation/#id1)
